### PR TITLE
fix: add `renderScrollComponent` for improved scrolling with pressables

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,21 +122,9 @@ A function to create custom animated pressables. It takes a worklet function tha
 
 A component to configure global settings for all pressable components within its children.
 
-## Contributing
+## Use with ScrollView and FlatList/FlashList
 
-Contributions are welcome! Please see our [contributing guide](CONTRIBUTING.md) for more details.
-
-## License
-
-MIT
-
----
-
-Made with ❤️ using [create-react-native-library](https://github.com/callstack/react-native-builder-bob)
-
-### Use with ScrollView and FlatList
-
-`pressto` provides a custom scroll component that enhances the scrolling experience when used with pressable components.
+`pressto` provides an optional custom scroll render component that enhances the scrolling experience when used with pressable components.
 
 ```jsx
 import { renderScrollComponent } from 'pressto';
@@ -156,3 +144,15 @@ function App() {
 
 The `renderScrollComponent` function wraps the scroll view with additional functionality in order to allow smoother interactions between scrolling and pressable components, preventing unwanted activations during scroll gestures.
 Applying the renderScrollComponent from `pressto` means that the tap gesture will be delayed for a short amount of time to understand if the tap gesture is a scroll or a tap gesture.
+
+## Contributing
+
+Contributions are welcome! Please see our [contributing guide](CONTRIBUTING.md) for more details.
+
+## License
+
+MIT
+
+---
+
+Made with ❤️ using [create-react-native-library](https://github.com/callstack/react-native-builder-bob)

--- a/README.md
+++ b/README.md
@@ -155,3 +155,4 @@ function App() {
 ```
 
 The `renderScrollComponent` function wraps the scroll view with additional functionality in order to allow smoother interactions between scrolling and pressable components, preventing unwanted activations during scroll gestures.
+Applying the renderScrollComponent from `pressto` means that the tap gesture will be delayed for a short amount of time to understand if the tap gesture is a scroll or a tap gesture.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ function BasicPressablesExample() {
   return (
     <View style={styles.container}>
       <PressableScale style={styles.box} onPress={() => console.log('scale')} />
-      <PressableOpacity style={styles.box} onPress={() => console.log('opacity')} />
+      <PressableOpacity
+        style={styles.box}
+        onPress={() => console.log('opacity')}
+      />
     </View>
   );
 }
-
 ```
 
 ### Create a custom Pressable with createAnimatedPressable
@@ -49,15 +51,16 @@ function BasicPressablesExample() {
 import { createAnimatedPressable } from 'pressto';
 
 const PressableRotate = createAnimatedPressable((progress) => ({
-  transform: [
-    { rotate: `${progress.value * Math.PI / 4}rad` },
-  ],
+  transform: [{ rotate: `${(progress.value * Math.PI) / 4}rad` }],
 }));
 
 function CustomPressableExample() {
   return (
     <View style={styles.container}>
-      <PressableRotate style={styles.box} onPress={() => console.log('rotate')} />
+      <PressableRotate
+        style={styles.box}
+        onPress={() => console.log('rotate')}
+      />
     </View>
   );
 }
@@ -73,22 +76,32 @@ import { PressablesConfig } from 'pressto';
 function App() {
   return (
     <View style={styles.container}>
-      <PressableRotate style={styles.box} onPress={() => console.log('rotate')} />
+      <PressableRotate
+        style={styles.box}
+        onPress={() => console.log('rotate')}
+      />
       <PressableScale style={styles.box} onPress={() => console.log('scale')} />
-      <PressableOpacity style={styles.box} onPress={() => console.log('opacity')} />
+      <PressableOpacity
+        style={styles.box}
+        onPress={() => console.log('opacity')}
+      />
     </View>
   );
 }
 
 export default () => (
-  <PressablesConfig animationType="spring" config={{ mass: 2 }} globalHandlers={{
-    onPress: () => {
-      console.log('you can call haptics here');
-    }
-  }}>
+  <PressablesConfig
+    animationType="spring"
+    config={{ mass: 2 }}
+    globalHandlers={{
+      onPress: () => {
+        console.log('you can call haptics here');
+      },
+    }}
+  >
     <App />
   </PressablesConfig>
-)
+);
 ```
 
 ## API
@@ -120,3 +133,25 @@ MIT
 ---
 
 Made with ❤️ using [create-react-native-library](https://github.com/callstack/react-native-builder-bob)
+
+### Use with ScrollView and FlatList
+
+`pressto` provides a custom scroll component that enhances the scrolling experience when used with pressable components.
+
+```jsx
+import { renderScrollComponent } from 'pressto';
+import { FlatList } from 'react-native';
+
+function App() {
+  return (
+    // This works with all the lists that support the renderScrollComponent prop
+    <FlatList
+      renderScrollComponent={renderScrollComponent}
+      data={data}
+      renderItem={({ item }) => <PressableRotate style={styles.box} />}
+    />
+  );
+}
+```
+
+The `renderScrollComponent` function wraps the scroll view with additional functionality in order to allow smoother interactions between scrolling and pressable components, preventing unwanted activations during scroll gestures.

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,10 +1,9 @@
 import {
   createAnimatedPressable,
-  PressableOpacity,
-  PressableScale,
   PressablesConfig,
+  renderScrollComponent,
 } from 'pressto';
-import { StyleSheet, View } from 'react-native';
+import { FlatList, StyleSheet, View } from 'react-native';
 import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
 import { interpolate, interpolateColor } from 'react-native-reanimated';
 
@@ -18,7 +17,7 @@ const PressableRotate = createAnimatedPressable((progress) => {
     backgroundColor: interpolateColor(
       progress.value,
       [0, 1],
-      ['#e4e4e4', '#ffffff']
+      ['#474747', '#000000']
     ),
     shadowColor: '#ffffff',
     shadowOffset: {
@@ -33,22 +32,12 @@ const PressableRotate = createAnimatedPressable((progress) => {
 function App() {
   return (
     <View style={styles.container}>
-      <PressableRotate
-        style={styles.box}
-        onPress={() => {
-          console.log('tap rotate :)');
-        }}
-      />
-      <PressableScale
-        style={styles.box}
-        onPress={() => {
-          console.log('tap scale :)');
-        }}
-      />
-      <PressableOpacity
-        style={styles.box}
-        onPress={() => {
-          console.log('tap opacity :)');
+      <FlatList
+        contentContainerStyle={styles.container}
+        data={new Array(10).fill(0)}
+        renderScrollComponent={renderScrollComponent}
+        renderItem={() => {
+          return <PressableRotate style={styles.box} />;
         }}
       />
     </View>
@@ -57,18 +46,16 @@ function App() {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#000000',
-    gap: 25,
+    // flex: 1,
+    backgroundColor: '#fff',
   },
   box: {
     width: 120,
     height: 120,
-    backgroundColor: '#cbcbcb',
+    backgroundColor: 'gray',
     borderRadius: 35,
     borderCurve: 'continuous',
+    alignSelf: 'center',
   },
 });
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -17,7 +17,7 @@ const PressableRotate = createAnimatedPressable((progress) => {
     backgroundColor: interpolateColor(
       progress.value,
       [0, 1],
-      ['#474747', '#000000']
+      ['#d1d1d1', '#000000']
     ),
     shadowColor: '#ffffff',
     shadowOffset: {
@@ -46,13 +46,22 @@ function App() {
 
 const styles = StyleSheet.create({
   container: {
-    // flex: 1,
+    paddingTop: 25,
     backgroundColor: '#fff',
+    gap: 10,
   },
   box: {
-    width: 120,
+    width: '95%',
     height: 120,
-    backgroundColor: 'gray',
+    elevation: 5,
+    shadowColor: '#000000',
+    shadowOffset: {
+      width: 0,
+      height: 0,
+    },
+    shadowOpacity: 0.5,
+    backgroundColor: 'red',
+    shadowRadius: 10,
     borderRadius: 35,
     borderCurve: 'continuous',
     alignSelf: 'center',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pressto",
-  "version": "0.1.8",
+  "version": "0.1.9-beta.0",
   "description": "Some custom react native touchables",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/pressables/base.tsx
+++ b/src/pressables/base.tsx
@@ -12,6 +12,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { usePressablesConfig } from '../provider';
 import type { PressableContextType } from '../provider/context';
+import { useIsInInternalScrollContext } from './render-scroll';
 import { unwrapSharedValue } from './utils';
 
 type AnimatedViewProps = AnimateProps<ViewProps>;
@@ -80,10 +81,13 @@ const BasePressable: React.FC<BasePressableProps> = ({
     return unwrapSharedValue(enabledProp);
   }, [enabledProp]);
 
+  const isInScrollContext = useIsInInternalScrollContext();
+
   const gesture = Gesture.Tap()
     .maxDuration(4000)
     .onTouchesDown(() => {
       if (!enabled.value) return;
+      if (isInScrollContext) return;
       active.value = true;
       if (onPressInProvider != null) runOnJS(onPressInProvider)();
       if (onPressIn != null) runOnJS(onPressIn)();

--- a/src/pressables/base.tsx
+++ b/src/pressables/base.tsx
@@ -116,44 +116,45 @@ const BasePressable: React.FC<BasePressableProps> = ({
     }
   );
 
-  const gesture = useMemo(
-    () =>
-      Gesture.Tap()
-        .maxDuration(4000)
-        .onTouchesDown(() => {
-          isTapped.value = true;
-          if (!isInScrollContext) {
-            return onBegin();
-          }
-        })
-        .onTouchesUp(() => {
-          if (!enabled.value || !active.value) return;
-          if (onPressProvider != null) runOnJS(onPressProvider)();
-          if (onPress != null) runOnJS(onPress)();
-        })
-        .onFinalize(() => {
-          isTapped.value = false;
-          if (!enabled.value || !active.value) return;
-          active.value = false;
-          if (onPressOutProvider != null) runOnJS(onPressOutProvider)();
-          if (onPressOut != null) runOnJS(onPressOut)();
-        }),
-    [
-      active,
-      enabled.value,
-      isInScrollContext,
-      isTapped,
-      onBegin,
-      onPress,
-      onPressOut,
-      onPressOutProvider,
-      onPressProvider,
-    ]
-  );
+  const gesture = useMemo(() => {
+    const tapGesture = Gesture.Tap()
+      .maxDuration(4000)
+      // check if enabledProp is a boolean
+      // if it's a boolean, use it to enable/disable the gesture
+      // if it's not a boolean, use the value of the enabled shared value (in each callback)
+      .enabled(typeof enabledProp === 'boolean' ? enabledProp : true)
+      .onTouchesDown(() => {
+        isTapped.value = true;
+        if (!isInScrollContext) {
+          return onBegin();
+        }
+      })
+      .onTouchesUp(() => {
+        if (!enabled.value || !active.value) return;
+        if (onPressProvider != null) runOnJS(onPressProvider)();
+        if (onPress != null) runOnJS(onPress)();
+      })
+      .onFinalize(() => {
+        isTapped.value = false;
+        if (!enabled.value || !active.value) return;
+        active.value = false;
+        if (onPressOutProvider != null) runOnJS(onPressOutProvider)();
+        if (onPressOut != null) runOnJS(onPressOut)();
+      });
 
-  if (typeof enabledProp === 'boolean') {
-    gesture.enabled(enabledProp);
-  }
+    return tapGesture;
+  }, [
+    active,
+    enabled.value,
+    enabledProp,
+    isInScrollContext,
+    isTapped,
+    onBegin,
+    onPress,
+    onPressOut,
+    onPressOutProvider,
+    onPressProvider,
+  ]);
 
   const rAnimatedStyle = useAnimatedStyle(() => {
     return animatedStyle ? animatedStyle(progress) : {};

--- a/src/pressables/index.ts
+++ b/src/pressables/index.ts
@@ -1,2 +1,3 @@
 export * from './custom';
 export * from './hoc';
+export * from './render-scroll';

--- a/src/pressables/render-scroll.tsx
+++ b/src/pressables/render-scroll.tsx
@@ -28,6 +28,10 @@ let timeout: NodeJS.Timeout | null = null;
 
 const callbacks = {
   onTouchStart: () => {
+    scrollableInfoShared.value = {
+      ...scrollableInfoShared.value,
+      activatedTap: false,
+    };
     timeout = setTimeout(() => {
       scrollableInfoShared.value = {
         ...scrollableInfoShared.value,

--- a/src/pressables/render-scroll.tsx
+++ b/src/pressables/render-scroll.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext } from 'react';
+import { ScrollView, type ScrollViewProps } from 'react-native';
+import { makeMutable } from 'react-native-reanimated';
+
+export const isScrolling = makeMutable(false);
+
+const InternalScrollContext = createContext(false);
+
+export const useScrollContext = () => {
+  return useContext(InternalScrollContext);
+};
+
+export const renderScrollComponent = ({
+  children,
+  ...props
+}: ScrollViewProps) => {
+  return (
+    <ScrollView
+      {...props}
+      onScrollBeginDrag={(event) => {
+        isScrolling.value = true;
+        return props.onScrollBeginDrag?.(event);
+      }}
+      onScrollEndDrag={(event) => {
+        isScrolling.value = false;
+        return props.onScrollEndDrag?.(event);
+      }}
+    >
+      <InternalScrollContext.Provider value={true}>
+        {children}
+      </InternalScrollContext.Provider>
+    </ScrollView>
+  );
+};

--- a/src/pressables/render-scroll.tsx
+++ b/src/pressables/render-scroll.tsx
@@ -1,21 +1,32 @@
-import { createContext, useContext } from 'react';
-import { ScrollView, type ScrollViewProps } from 'react-native';
+import { createContext, forwardRef, useContext } from 'react';
+import type { ScrollViewProps } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
 import { makeMutable } from 'react-native-reanimated';
 
 export const isScrolling = makeMutable(false);
 
-const InternalScrollContext = createContext(false);
+const InternalScrollableContext = createContext(false);
 
-export const useScrollContext = () => {
-  return useContext(InternalScrollContext);
+export const useIsInInternalScrollContext = () => {
+  return useContext(InternalScrollableContext);
 };
+
+const InternalScrollView = forwardRef<ScrollView, ScrollViewProps>(
+  (props, ref) => {
+    return (
+      <InternalScrollableContext.Provider value={true}>
+        <ScrollView {...(props as any)} ref={ref} />
+      </InternalScrollableContext.Provider>
+    );
+  }
+);
 
 export const renderScrollComponent = ({
   children,
   ...props
 }: ScrollViewProps) => {
   return (
-    <ScrollView
+    <InternalScrollView
       {...props}
       onScrollBeginDrag={(event) => {
         isScrolling.value = true;
@@ -26,9 +37,7 @@ export const renderScrollComponent = ({
         return props.onScrollEndDrag?.(event);
       }}
     >
-      <InternalScrollContext.Provider value={true}>
-        {children}
-      </InternalScrollContext.Provider>
-    </ScrollView>
+      {children}
+    </InternalScrollView>
   );
 };


### PR DESCRIPTION
This PR introduces `renderScrollComponent`, enhancing the scrolling experience when using pressable components inside scrollable views (e.g., ScrollView, FlatList, FlashList).

## What it does
- Prevents accidental activations of pressable components during scrolling
- Adds a short delay (75ms) to distinguish between scrolls and taps

## How to use it
```jsx
import { renderScrollComponent } from 'pressto';

<FlatList
  renderScrollComponent={renderScrollComponent}
  data={data}
  renderItem={({ item }) => <PressableRotate style={styles.box} />}
/>
```

## Implementation details
- Uses `makeMutable` from 'react-native-reanimated' to create `scrollableInfoShared`, tracking scroll and tap state efficiently
- Implements `InternalScrollView`, a forwarded ref component wrapping ScrollView and providing scrollable context
- Defines callbacks for touch and scroll events:
  - `onTouchStart`: Sets a 75ms timeout to activate tap
  - `onScrollBeginDrag`: Clears timeout and marks scrolling as active
  - `onScrollEndDrag`: Marks scrolling as inactive
  - `onTouchEnd`: Clears timeout and resets tap state
- Exports `renderScrollComponent` that applies these callbacks to the scroll view

This approach allows for precise distinction between scrolling and tapping intentions, improving overall user experience.

https://github.com/user-attachments/assets/6c6c22fb-9a72-433c-b7c3-96ae443e5a52

