### PR TITLE
docs: create animated pressable section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ function BasicPressablesExample() {
 ```jsx
 import { createAnimatedPressable } from 'pressto';
 
-const PressableRotate = createAnimatedPressable((progress) => ({
-  transform: [{ rotate: `${(progress.value * Math.PI) / 4}rad` }],
-}));
+const PressableRotate = createAnimatedPressable((progress) => {
+  'worklet';
+  return {
+    transform: [{ rotate: `${(progress.value * Math.PI) / 4}rad` }],
+  };
+});
 
 function CustomPressableExample() {
   return (


### PR DESCRIPTION
Fix the wrong docs section about "_createAnimatedPressable_". 

Related to https://github.com/enzomanuelmangano/pressto/issues/3#issue-2571881822 