### PR TITLE
type: add onLongPress prop type support

### DIFF
--- a/src/pressables/base.tsx
+++ b/src/pressables/base.tsx
@@ -24,6 +24,7 @@ export type BasePressableProps = {
     Pick<
       AnimatedPressableProps,
       | 'layout'
+      | 'onLongPress'
       | 'entering'
       | 'exiting'
       | 'style'


### PR DESCRIPTION
Easy fix, as now it's built on top of BaseButton