### PR TITLE
feat: default props in pressable config

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,32 @@ function App() {
 - `animationConfig`: Pass timing or spring configuration
 - `config`: Set default values for `minScale`, `activeOpacity`, `baseScale`
 
+### Default Props
+
+Set default props for all pressables globally. Useful for platform-specific behavior like disabling the Android ripple effect:
+
+```jsx
+import { PressablesConfig, PressableScale } from 'pressto';
+
+function App() {
+  return (
+    <PressablesConfig defaultProps={{ rippleColor: 'transparent' }}>
+      {/* All pressables will have ripple disabled */}
+      <PressableScale onPress={() => console.log('No ripple!')}>
+        <Text>Press me</Text>
+      </PressableScale>
+
+      {/* Individual pressables can still override */}
+      <PressableScale rippleColor="blue" onPress={() => {}}>
+        <Text>This one has blue ripple</Text>
+      </PressableScale>
+    </PressablesConfig>
+  );
+}
+```
+
+**Available props:** `rippleColor`, `rippleRadius`, `touchSoundDisabled`, `hitSlop`, accessibility props, and more.
+
 ### Global Handlers
 
 Add global handlers like haptic feedback:
@@ -279,6 +305,7 @@ Global configuration provider.
 - `animationType`: 'timing' | 'spring' - Default: 'timing'
 - `animationConfig`: Timing/spring config object
 - `config`: { activeOpacity, minScale, baseScale }
+- `defaultProps`: Default props applied to all pressables (e.g., `rippleColor`, `hitSlop`)
 - `globalHandlers`: { onPress, onPressIn, onPressOut }
 - `metadata`: Custom theme/config (type-safe)
 - `activateOnHover`: boolean - Web only

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pressto",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.0",
   "description": "Some custom react native touchables",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/pressables/base.tsx
+++ b/src/pressables/base.tsx
@@ -138,6 +138,7 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
       metadata,
       activateOnHover: activateOnHoverProvider,
       config,
+      defaultProps,
     } = usePressablesConfig();
 
     const lastTouchedPressable = useLastTouchedPressable();
@@ -317,9 +318,15 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
       return children;
     }, [children, childrenCallbackParams]);
 
+    // Merge defaultProps from context with component props (component props take precedence)
+    const mergedProps = useMemo(
+      () => ({ ...defaultProps, ...rest }),
+      [defaultProps, rest]
+    );
+
     return (
       <AnimatedBaseButton
-        {...rest}
+        {...mergedProps}
         {...(hoverProps as any)}
         style={[rest?.style ?? {}, rAnimatedStyle, cursorStyle]}
         enabled={enabled}

--- a/src/provider/constants.ts
+++ b/src/provider/constants.ts
@@ -1,4 +1,35 @@
+import type { ComponentProps } from 'react';
+import type { BaseButton } from 'react-native-gesture-handler';
 import { Easing } from 'react-native-reanimated';
+
+/**
+ * Props that can be set globally via PressablesConfig and applied to all pressables.
+ * These are "passthrough" props that don't conflict with internally managed props
+ * like style, enabled, animation settings, or event handlers.
+ */
+export type DefaultPressableProps = Partial<
+  Pick<
+    ComponentProps<typeof BaseButton>,
+    | 'hitSlop'
+    | 'testID'
+    | 'userSelect'
+    | 'activeCursor'
+    | 'shouldCancelWhenOutside'
+    | 'cancelsTouchesInView'
+    | 'enableContextMenu'
+    | 'rippleColor'
+    | 'rippleRadius'
+    | 'touchSoundDisabled'
+    | 'waitFor'
+    | 'simultaneousHandlers'
+    | 'accessibilityHint'
+    | 'accessibilityLabel'
+    | 'accessibilityRole'
+    | 'accessibilityState'
+    | 'accessibilityValue'
+    | 'accessibilityActions'
+  >
+>;
 
 /**
  * Configuration values for pressable visual feedback

--- a/src/provider/context.ts
+++ b/src/provider/context.ts
@@ -5,7 +5,12 @@ import {
   type WithSpringConfig,
   type WithTimingConfig,
 } from 'react-native-reanimated';
-import { DefaultAnimationConfigs, DefaultPressableConfig, type PressableConfig } from './constants';
+import {
+  DefaultAnimationConfigs,
+  DefaultPressableConfig,
+  type DefaultPressableProps,
+  type PressableConfig,
+} from './constants';
 
 export type AnimationType = 'timing' | 'spring';
 
@@ -36,6 +41,11 @@ export type PressableContextType<
    * Pressable configuration values (opacity, scale, etc.)
    */
   config: PressableConfig;
+  /**
+   * Default props applied to all pressables.
+   * Individual pressable props will override these values.
+   */
+  defaultProps?: DefaultPressableProps;
 };
 
 export const PressablesContext = createContext<

--- a/src/provider/index.tsx
+++ b/src/provider/index.tsx
@@ -5,7 +5,12 @@ import {
   type WithTimingConfig,
 } from 'react-native-reanimated';
 
-import { DefaultAnimationConfigs, DefaultPressableConfig, type PressableConfig } from './constants';
+import {
+  DefaultAnimationConfigs,
+  DefaultPressableConfig,
+  type DefaultPressableProps,
+  type PressableConfig,
+} from './constants';
 import {
   PressablesContext,
   PressablesGroupContext,
@@ -35,6 +40,17 @@ export type PressablesConfigProps<
    * Pressable configuration values (opacity, scale, etc.)
    */
   config?: Partial<PressableConfig>;
+  /**
+   * Default props applied to all pressables.
+   * Individual pressable props will override these values.
+   *
+   * @example
+   * // Disable ripple effect globally on Android
+   * <PressablesConfig defaultProps={{ rippleColor: 'transparent' }}>
+   *   ...
+   * </PressablesConfig>
+   */
+  defaultProps?: DefaultPressableProps;
 };
 
 export const PressablesGroup = ({ children }: PropsWithChildren) => {
@@ -61,6 +77,7 @@ export const PressablesConfig = <T extends AnimationType, TMetadata = unknown>({
   metadata,
   activateOnHover,
   config,
+  defaultProps,
 }: PressablesConfigProps<T, TMetadata>) => {
   const value = useMemo(() => {
     return {
@@ -70,8 +87,9 @@ export const PressablesConfig = <T extends AnimationType, TMetadata = unknown>({
       metadata,
       activateOnHover,
       config: { ...DefaultPressableConfig, ...config },
+      defaultProps,
     };
-  }, [animationType, animationConfig, globalHandlers, metadata, activateOnHover, config]);
+  }, [animationType, animationConfig, globalHandlers, metadata, activateOnHover, config, defaultProps]);
 
   return (
     <PressablesContext.Provider value={value}>
@@ -81,4 +99,4 @@ export const PressablesConfig = <T extends AnimationType, TMetadata = unknown>({
 };
 
 export * from './hooks';
-export type { PressableConfig } from './constants';
+export type { DefaultPressableProps, PressableConfig } from './constants';


### PR DESCRIPTION
## Summary

Adds a new `defaultProps` option to `PressablesConfig` that allows setting default props for all pressables globally. This is useful for platform-specific behavior like disabling the Android ripple effect without having to set it on every individual component.

Closes #28 (thanks @timonla for the suggestion!)

## Usage

```tsx
<PressablesConfig defaultProps={{ rippleColor: 'transparent' }}>
  {/* All pressables will have ripple disabled */}
  <PressableScale onPress={() => {}}>
    <Text>No ripple</Text>
  </PressableScale>

  {/* Individual pressables can still override */}
  <PressableScale rippleColor="blue" onPress={() => {}}>
    <Text>Blue ripple</Text>
  </PressableScale>
</PressablesConfig>
```

## Available Props

The following props can be set globally via `defaultProps`:
- `rippleColor`, `rippleRadius`, `touchSoundDisabled`
- `hitSlop`, `testID`
- `userSelect`, `activeCursor`
- `shouldCancelWhenOutside`, `cancelsTouchesInView`, `enableContextMenu`
- `waitFor`, `simultaneousHandlers`
- Accessibility props (`accessibilityHint`, `accessibilityLabel`, etc.)

Props like `style`, `enabled`, animation settings, and event handlers are intentionally excluded to avoid conflicts with internally managed behavior.

## Test Plan

- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] Tested `rippleColor: 'transparent'` on Android - ripple disabled
- [x] Individual component props override global defaults

---

🤖 Generated with [Claude Code](https://claude.ai/code)