### PR TITLE
feat: propagate testID to accessibilityIdentifier for e2e discovery

### DIFF
--- a/src/__tests__/accessibility.test.tsx
+++ b/src/__tests__/accessibility.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react-native';
+
+import { PressableOpacity } from '../pressables/custom/opacity';
+import { PressableScale } from '../pressables/custom/scale';
+import { PressableWithoutFeedback } from '../pressables/custom/withoutFeedback';
+
+describe.each([
+  ['PressableScale', PressableScale],
+  ['PressableOpacity', PressableOpacity],
+  ['PressableWithoutFeedback', PressableWithoutFeedback],
+])('%s accessibility identifier', (_name, Component) => {
+  it('mirrors testID to accessibilityIdentifier', () => {
+    render(<Component testID="save-button" />);
+    expect(screen.getByTestId('save-button').props.accessibilityIdentifier).toBe(
+      'save-button'
+    );
+  });
+
+  it('lets an explicit accessibilityIdentifier override testID', () => {
+    render(
+      <Component testID="save-button" accessibilityIdentifier="custom-id" />
+    );
+    expect(screen.getByTestId('save-button').props.accessibilityIdentifier).toBe(
+      'custom-id'
+    );
+  });
+
+  it('is accessible by default', () => {
+    render(<Component testID="p" />);
+    expect(screen.getByTestId('p').props.accessible).toBe(true);
+  });
+
+  it('respects an explicit accessible={false}', () => {
+    render(<Component testID="p" accessible={false} />);
+    expect(screen.getByTestId('p').props.accessible).toBe(false);
+  });
+});
+
+describe('accessibilityIdentifier from defaultProps testID fallback', () => {
+  it('falls back to testID when no explicit identifier is given', () => {
+    render(<PressableScale testID="only-test-id" />);
+    const el = screen.getByTestId('only-test-id');
+    expect(el.props.accessibilityIdentifier).toBe('only-test-id');
+  });
+});

--- a/src/pressables/base.tsx
+++ b/src/pressables/base.tsx
@@ -78,6 +78,11 @@ export type BasePressableProps<TMetadata = unknown> = {
   enabled?: boolean;
   /** Disables the pressable. Takes precedence over `enabled`. */
   disabled?: boolean;
+  /**
+   * Native accessibility identifier used by e2e runners (Maestro, XCUITest,
+   * Detox). Defaults to `testID` when omitted.
+   */
+  accessibilityIdentifier?: string;
   initialToggled?: boolean;
   /**
    * Activates the pressable animation on hover (web only)
@@ -98,6 +103,7 @@ export type BasePressableProps<TMetadata = unknown> = {
       | 'style'
       | 'hitSlop'
       | 'testID'
+      | 'accessible'
       | 'userSelect'
       | 'activeCursor'
       | 'shouldCancelWhenOutside'
@@ -134,6 +140,7 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
     animationConfig: animationConfigProp,
     enabled = true,
     disabled,
+    accessibilityIdentifier: accessibilityIdentifierProp,
     initialToggled = false,
     activateOnHover: activateOnHoverProp,
     ...rest
@@ -333,9 +340,20 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
       [defaultProps, rest]
     );
 
+    // Mirror RN convention (Pressable / TouchableOpacity): testID becomes the
+    // native accessibilityIdentifier on iOS, and tappable controls are
+    // accessibility elements by default. RNGH's BaseButton accepts testID but
+    // does NOT propagate it, so e2e runners (Maestro, XCUITest, Detox) can't
+    // locate pressto buttons by id without this. Both stay overridable.
+    const accessibilityIdentifier =
+      accessibilityIdentifierProp ?? mergedProps.testID;
+    const accessible = mergedProps.accessible ?? true;
+
     return (
       <AnimatedBaseButton
         {...mergedProps}
+        {...({ accessibilityIdentifier } as any)}
+        accessible={accessible}
         {...(hoverProps as any)}
         style={[rest?.style ?? {}, rAnimatedStyle, cursorStyle]}
         enabled={isEnabled}


### PR DESCRIPTION
## Summary

RNGH's `BaseButton` accepts `testID` but does **not** propagate it to the native view, so e2e runners (Maestro, XCUITest, Detox) can't locate pressto buttons by id. This mirrors React Native's `Pressable`/`TouchableOpacity` convention:

- maps `testID` → native `accessibilityIdentifier` (overridable via an explicit `accessibilityIdentifier` prop)
- defaults `accessible` to `true` so the element appears in the iOS accessibility tree (required for XCUITest/Maestro to find it by identifier), matching `Pressable.js`'s `accessible !== false`; explicit `accessible={false}` is respected

Ports the patch already used in the ennio app.

### Why `accessible` defaults to true
Verified against RN source: `Pressable.js` → `accessible: accessible !== false`, `TouchableOpacity.js` → `accessible={this.props.accessible !== false}`. Both default true unconditionally. `mergedProps.accessible ?? true` is behaviourally identical, so pressto stays consistent with RN rather than diverging.

## Test plan

- [x] 13 new tests in `accessibility.test.tsx` (testID→accessibilityIdentifier mapping, explicit override, accessible default true, explicit false respected) across all three pressables
- [x] full suite 65/65, lint + typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)