### PR TITLE
feat: per-component metadata in handlers + skipGlobalHandlers (#26, #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,8 +313,20 @@ Creates a custom animated pressable.
   - `options.isPressed`: boolean - Currently being pressed
   - `options.isToggled`: boolean - Toggle state (persistent)
   - `options.isSelected`: boolean - Selected in group
-  - `options.metadata`: TMetadata - Custom theme data
+  - `options.metadata`: TMetadata - Per-component metadata (falls back to PressablesConfig)
   - `options.config`: PressableConfig - Default values (minScale, activeOpacity, baseScale)
+
+### Per-pressable props
+
+Every pressable (`PressableScale`, `PressableOpacity`, custom ones from `createAnimatedPressable`) accepts:
+
+- `onPress` / `onPressIn` / `onPressOut`: `(options) => void` — `options` is `{ isPressed, isToggled, isSelected, metadata }`
+- `disabled`: boolean - Disables interaction (replaces the deprecated `enabled`)
+- `metadata`: TMetadata - Per-component metadata; passed to the handlers (incl. `globalHandlers`) and overrides the `PressablesConfig` metadata
+- `skipGlobalHandlers`: boolean - Opt out of `PressablesConfig` `globalHandlers` (own handlers still fire)
+- `accessibilityIdentifier`: string - Native id for e2e runners; defaults to `testID`
+- `initialToggled`: boolean - Initial toggle state
+- `activateOnHover`: boolean - Web only
 
 ### `PressablesConfig`
 
@@ -326,8 +338,8 @@ Global configuration provider.
 - `animationConfig`: Timing/spring config object
 - `config`: { activeOpacity, minScale, baseScale }
 - `defaultProps`: Default props applied to all pressables (e.g., `rippleColor`, `hitSlop`)
-- `globalHandlers`: { onPress, onPressIn, onPressOut }
-- `metadata`: Custom theme/config (type-safe)
+- `globalHandlers`: { onPress, onPressIn, onPressOut } - Receive each pressable's `metadata`; opt a pressable out with `skipGlobalHandlers`
+- `metadata`: Default metadata for all pressables (type-safe); overridable per component
 - `activateOnHover`: boolean - Web only
 
 ### `PressableConfig`

--- a/README.md
+++ b/README.md
@@ -168,6 +168,26 @@ function App() {
 }
 ```
 
+Opt a single pressable out of the global handlers with `skipGlobalHandlers` — its own `onPress`/`onPressIn`/`onPressOut` still fire:
+
+```jsx
+{/* No global haptics for this one button */}
+<PressableScale skipGlobalHandlers onPress={() => {}} />
+```
+
+Identify which pressable fired inside a global handler with per-component `metadata`. It is passed to the handler options (and overrides the `metadata` set on `PressablesConfig`):
+
+```jsx
+<PressablesConfig
+  globalHandlers={{
+    onPress: ({ metadata }) => track('tap', metadata?.name),
+  }}
+>
+  <PressableScale metadata={{ name: 'checkout' }} />
+  <PressableScale metadata={{ name: 'cancel' }} />
+</PressablesConfig>
+```
+
 ---
 
 ## Advanced Features

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Opt a single pressable out of the global handlers with `skipGlobalHandlers` — 
 <PressableScale skipGlobalHandlers onPress={() => {}} />
 ```
 
-Identify which pressable fired inside a global handler with per-component `metadata`. It is passed to the handler options (and overrides the `metadata` set on `PressablesConfig`):
+Identify which pressable fired inside a global handler with per-component `metadata`. It is passed to the handler options. A component's `metadata` **replaces** (does not merge with) the `metadata` set on `PressablesConfig` — spread them yourself to combine: `metadata={{ ...theme, name: 'checkout' }}`.
 
 ```jsx
 <PressablesConfig
@@ -322,7 +322,7 @@ Every pressable (`PressableScale`, `PressableOpacity`, custom ones from `createA
 
 - `onPress` / `onPressIn` / `onPressOut`: `(options) => void` — `options` is `{ isPressed, isToggled, isSelected, metadata }`
 - `disabled`: boolean - Disables interaction (replaces the deprecated `enabled`)
-- `metadata`: TMetadata - Per-component metadata; passed to the handlers (incl. `globalHandlers`) and overrides the `PressablesConfig` metadata
+- `metadata`: TMetadata - Per-component metadata; passed to the handlers (incl. `globalHandlers`). Replaces (does not merge with) the `PressablesConfig` metadata
 - `skipGlobalHandlers`: boolean - Opt out of `PressablesConfig` `globalHandlers` (own handlers still fire)
 - `accessibilityIdentifier`: string - Native id for e2e runners; defaults to `testID`
 - `initialToggled`: boolean - Initial toggle state

--- a/example/app/global-handlers-example.tsx
+++ b/example/app/global-handlers-example.tsx
@@ -1,0 +1,126 @@
+import { createAnimatedPressable, PressablesConfig } from 'pressto';
+import { useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { interpolate, interpolateColor } from 'react-native-reanimated';
+
+// Metadata shape this screen attaches to each button.
+type ButtonMeta = { name: string };
+
+const Button = createAnimatedPressable<ButtonMeta>((progress, { metadata }) => {
+  'worklet';
+  return {
+    transform: [{ scale: interpolate(progress, [0, 1], [1, 0.96]) }],
+    backgroundColor: interpolateColor(
+      progress,
+      [0, 1],
+      ['#1E293B', '#334155']
+    ),
+    borderRadius: 16,
+    padding: 20,
+    // metadata is available in the worklet too
+    borderWidth: metadata?.name === 'silent' ? 1 : 0,
+    borderColor: '#64748B',
+  };
+});
+
+export default function GlobalHandlersExample() {
+  const [lastGlobal, setLastGlobal] = useState('—');
+  const [lastLocal, setLastLocal] = useState('—');
+
+  return (
+    // A global handler that reads each button's metadata (issue #26).
+    <PressablesConfig
+      metadata={{ name: 'unknown' } as ButtonMeta}
+      globalHandlers={{
+        onPress: ({ metadata }) => setLastGlobal(metadata?.name ?? 'unknown'),
+      }}
+    >
+      <View style={styles.container}>
+        <Text style={styles.title}>Global Handlers + Metadata</Text>
+
+        <View style={styles.readout}>
+          <Text style={styles.readoutLabel}>global handler saw</Text>
+          <Text style={styles.readoutValue}>{lastGlobal}</Text>
+          <Text style={styles.readoutLabel}>component handler saw</Text>
+          <Text style={styles.readoutValue}>{lastLocal}</Text>
+        </View>
+
+        <View style={styles.section}>
+          {/* metadata reaches the global handler */}
+          <Button
+            metadata={{ name: 'checkout' }}
+            onPress={() => setLastLocal('checkout')}
+          >
+            <Text style={styles.buttonText}>Checkout</Text>
+            <Text style={styles.hint}>global handler logs &quot;checkout&quot;</Text>
+          </Button>
+
+          <Button
+            metadata={{ name: 'cancel' }}
+            onPress={() => setLastLocal('cancel')}
+          >
+            <Text style={styles.buttonText}>Cancel</Text>
+            <Text style={styles.hint}>global handler logs &quot;cancel&quot;</Text>
+          </Button>
+
+          {/* skipGlobalHandlers: the global handler does NOT fire (issue #30) */}
+          <Button
+            metadata={{ name: 'silent' }}
+            skipGlobalHandlers
+            onPress={() => setLastLocal('silent')}
+          >
+            <Text style={styles.buttonText}>Silent (skipGlobalHandlers)</Text>
+            <Text style={styles.hint}>
+              own onPress fires, global handler is skipped
+            </Text>
+          </Button>
+        </View>
+      </View>
+    </PressablesConfig>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#0F172A',
+    gap: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#F1F5F9',
+  },
+  readout: {
+    backgroundColor: '#1E293B',
+    borderRadius: 12,
+    padding: 16,
+    gap: 4,
+  },
+  readoutLabel: {
+    fontSize: 12,
+    color: '#94A3B8',
+  },
+  readoutValue: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#F1F5F9',
+    marginBottom: 8,
+  },
+  section: {
+    gap: 16,
+  },
+  buttonText: {
+    fontSize: 16,
+    color: '#FFF',
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  hint: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.7)',
+    marginTop: 4,
+    textAlign: 'center',
+  },
+});

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -39,6 +39,13 @@ export default function Page() {
       >
         <Text style={styles.buttonText}>Theme Metadata</Text>
       </PressableHighlight>
+
+      <PressableHighlight
+        onPress={() => router.navigate('/global-handlers-example')}
+        style={styles.button}
+      >
+        <Text style={styles.buttonText}>Global Handlers + Metadata</Text>
+      </PressableHighlight>
       {Platform.OS === 'web' && (
         <PressableHighlight
           onPress={() => console.log("won't activate on hover")}

--- a/src/__tests__/backward-compat.test.tsx
+++ b/src/__tests__/backward-compat.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Guards backward compatibility for users upgrading pressto.
+ * Every pattern here is written exactly as it worked BEFORE per-component
+ * metadata / skipGlobalHandlers were added. If any of it stops compiling or
+ * behaving, this PR introduced a breaking change.
+ */
+import { render, screen, fireEvent } from '@testing-library/react-native';
+
+import {
+  createAnimatedPressable,
+  PressableScale,
+  PressableOpacity,
+  PressableWithoutFeedback,
+  PressablesConfig,
+  type CustomPressableProps,
+  type AnimatedPressableOptions,
+} from '../index';
+
+describe('backward compatibility', () => {
+  it('old onPress signature (options without metadata) still works', () => {
+    const onPress = jest.fn();
+    // pre-PR handler: only reads the original three fields
+    const handler = (options: AnimatedPressableOptions) => {
+      onPress(options.isPressed, options.isToggled, options.isSelected);
+    };
+    render(<PressableScale testID="p" onPress={handler} />);
+    fireEvent.press(screen.getByTestId('p'));
+    // isPressed=false (released), isToggled=true (flipped), isSelected=true
+    // (becomes the last touched). Unchanged from pre-PR behaviour.
+    expect(onPress).toHaveBeenCalledWith(false, true, true);
+  });
+
+  it('CustomPressableProps still usable without a type argument (issue #20 pattern)', () => {
+    // dwieners' NativeWind workaround typed components as FC<CustomPressableProps>
+    const props: CustomPressableProps = { onPress: () => {} };
+    render(<PressableScale testID="p" {...props} />);
+    expect(screen.getByTestId('p')).toBeTruthy();
+  });
+
+  it('themed createAnimatedPressable<Theme> worklet: metadata stays required (no ?.)', () => {
+    type Theme = { colors: { primary: string } };
+    const Themed = createAnimatedPressable<Theme>((progress, { metadata }) => {
+      'worklet';
+      // no optional chaining — proves animatedStyle metadata is non-optional
+      return { backgroundColor: metadata.colors.primary, opacity: progress };
+    });
+    render(
+      <PressablesConfig metadata={{ colors: { primary: '#f00' } }}>
+        <Themed testID="themed" />
+      </PressablesConfig>
+    );
+    expect(screen.getByTestId('themed')).toBeTruthy();
+  });
+
+  it('PressablesConfig with old-style globalHandlers still fires for all pressables', () => {
+    const globalOnPress = jest.fn();
+    render(
+      <PressablesConfig globalHandlers={{ onPress: () => globalOnPress() }}>
+        <PressableScale testID="a" />
+        <PressableOpacity testID="b" />
+        <PressableWithoutFeedback testID="c" />
+      </PressablesConfig>
+    );
+    fireEvent.press(screen.getByTestId('a'));
+    fireEvent.press(screen.getByTestId('b'));
+    fireEvent.press(screen.getByTestId('c'));
+    expect(globalOnPress).toHaveBeenCalledTimes(3);
+  });
+
+  it('a pressable with none of the new props behaves identically', () => {
+    const onPress = jest.fn();
+    render(<PressableScale testID="p" onPress={onPress} />);
+    fireEvent.press(screen.getByTestId('p'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/metadata.test.tsx
+++ b/src/__tests__/metadata.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent } from '@testing-library/react-native';
+
+import { PressablesConfig } from '../provider';
+import { PressableScale } from '../pressables/custom/scale';
+
+describe('per-component metadata', () => {
+  it('reaches the component onPress handler', () => {
+    const onPress = jest.fn();
+    render(
+      <PressableScale testID="p" metadata={{ name: 'checkout' }} onPress={onPress} />
+    );
+    fireEvent.press(screen.getByTestId('p'));
+    expect(onPress).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { name: 'checkout' } })
+    );
+  });
+
+  it('reaches a global onPress handler (issue #26)', () => {
+    const globalOnPress = jest.fn();
+    render(
+      <PressablesConfig globalHandlers={{ onPress: globalOnPress }}>
+        <PressableScale testID="p" metadata={{ name: 'checkout' }} />
+      </PressablesConfig>
+    );
+    fireEvent.press(screen.getByTestId('p'));
+    expect(globalOnPress).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { name: 'checkout' } })
+    );
+  });
+
+  it('reaches onPressIn and onPressOut handlers', () => {
+    const onPressIn = jest.fn();
+    const onPressOut = jest.fn();
+    render(
+      <PressableScale
+        testID="p"
+        metadata={{ name: 'x' }}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+      />
+    );
+    const button = screen.getByTestId('p');
+    fireEvent(button, 'began');
+    fireEvent(button, 'ended');
+    expect(onPressIn).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { name: 'x' } })
+    );
+    expect(onPressOut).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { name: 'x' } })
+    );
+  });
+
+  it('overrides PressablesConfig metadata', () => {
+    const globalOnPress = jest.fn();
+    render(
+      <PressablesConfig
+        metadata={{ name: 'global' }}
+        globalHandlers={{ onPress: globalOnPress }}
+      >
+        <PressableScale testID="p" metadata={{ name: 'local' }} />
+      </PressablesConfig>
+    );
+    fireEvent.press(screen.getByTestId('p'));
+    expect(globalOnPress).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { name: 'local' } })
+    );
+  });
+
+  it('falls back to PressablesConfig metadata when the component omits it', () => {
+    const globalOnPress = jest.fn();
+    render(
+      <PressablesConfig
+        metadata={{ name: 'global' }}
+        globalHandlers={{ onPress: globalOnPress }}
+      >
+        <PressableScale testID="p" />
+      </PressablesConfig>
+    );
+    fireEvent.press(screen.getByTestId('p'));
+    expect(globalOnPress).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { name: 'global' } })
+    );
+  });
+
+  it('is undefined when set nowhere', () => {
+    const onPress = jest.fn();
+    render(<PressableScale testID="p" onPress={onPress} />);
+    fireEvent.press(screen.getByTestId('p'));
+    expect(onPress.mock.calls[0][0].metadata).toBeUndefined();
+  });
+});

--- a/src/__tests__/skip-global-handlers.test.tsx
+++ b/src/__tests__/skip-global-handlers.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from '@testing-library/react-native';
+
+import { PressablesConfig } from '../provider';
+import { PressableScale } from '../pressables/custom/scale';
+
+describe('skipGlobalHandlers', () => {
+  it('opts out of the global onPress handler (issue #30)', () => {
+    const globalOnPress = jest.fn();
+    render(
+      <PressablesConfig globalHandlers={{ onPress: globalOnPress }}>
+        <PressableScale testID="p" skipGlobalHandlers />
+      </PressablesConfig>
+    );
+    fireEvent.press(screen.getByTestId('p'));
+    expect(globalOnPress).not.toHaveBeenCalled();
+  });
+
+  it('still fires the component own onPress', () => {
+    const globalOnPress = jest.fn();
+    const onPress = jest.fn();
+    render(
+      <PressablesConfig globalHandlers={{ onPress: globalOnPress }}>
+        <PressableScale testID="p" skipGlobalHandlers onPress={onPress} />
+      </PressablesConfig>
+    );
+    fireEvent.press(screen.getByTestId('p'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(globalOnPress).not.toHaveBeenCalled();
+  });
+
+  it('also skips global onPressIn and onPressOut', () => {
+    const globalOnPressIn = jest.fn();
+    const globalOnPressOut = jest.fn();
+    render(
+      <PressablesConfig
+        globalHandlers={{
+          onPressIn: globalOnPressIn,
+          onPressOut: globalOnPressOut,
+        }}
+      >
+        <PressableScale testID="p" skipGlobalHandlers />
+      </PressablesConfig>
+    );
+    const button = screen.getByTestId('p');
+    fireEvent(button, 'began');
+    fireEvent(button, 'ended');
+    expect(globalOnPressIn).not.toHaveBeenCalled();
+    expect(globalOnPressOut).not.toHaveBeenCalled();
+  });
+
+  it('global handlers fire when skipGlobalHandlers is not set', () => {
+    const globalOnPress = jest.fn();
+    render(
+      <PressablesConfig globalHandlers={{ onPress: globalOnPress }}>
+        <PressableScale testID="p" />
+      </PressablesConfig>
+    );
+    fireEvent.press(screen.getByTestId('p'));
+    expect(globalOnPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not break a pressable with no global handlers', () => {
+    const onPress = jest.fn();
+    render(<PressableScale testID="p" skipGlobalHandlers onPress={onPress} />);
+    fireEvent.press(screen.getByTestId('p'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pressables/base.tsx
+++ b/src/pressables/base.tsx
@@ -83,6 +83,18 @@ export type BasePressableProps<TMetadata = unknown> = {
    * Detox). Defaults to `testID` when omitted.
    */
   accessibilityIdentifier?: string;
+  /**
+   * Per-component metadata, surfaced to `animatedStyle` and to the press
+   * handler options (including globalHandlers). Overrides the metadata set on
+   * PressablesConfig. Use it to identify a pressable inside a global handler
+   * (e.g. analytics name) or carry flags it should react to.
+   */
+  metadata?: TMetadata;
+  /**
+   * Opt this pressable out of the globalHandlers defined on PressablesConfig.
+   * The component's own onPress/onPressIn/onPressOut still fire.
+   */
+  skipGlobalHandlers?: boolean;
   initialToggled?: boolean;
   /**
    * Activates the pressable animation on hover (web only)
@@ -122,9 +134,9 @@ export type BasePressableProps<TMetadata = unknown> = {
       | 'accessibilityActions'
     >
   > & {
-    onPress?: (options: AnimatedPressableOptions) => void;
-    onPressIn?: (options: AnimatedPressableOptions) => void;
-    onPressOut?: (options: AnimatedPressableOptions) => void;
+    onPress?: (options: AnimatedPressableOptions<TMetadata>) => void;
+    onPressIn?: (options: AnimatedPressableOptions<TMetadata>) => void;
+    onPressOut?: (options: AnimatedPressableOptions<TMetadata>) => void;
   };
 
 const cursorStyle = Platform.OS === 'web' ? { cursor: 'pointer' as const } : {};
@@ -141,6 +153,8 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
     enabled = true,
     disabled,
     accessibilityIdentifier: accessibilityIdentifierProp,
+    metadata: metadataProp,
+    skipGlobalHandlers = false,
     initialToggled = false,
     activateOnHover: activateOnHoverProp,
     ...rest
@@ -149,7 +163,7 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
       animationType: animationTypeProvider,
       animationConfig: animationConfigProvider,
       globalHandlers,
-      metadata,
+      metadata: metadataProvider,
       activateOnHover: activateOnHoverProvider,
       config,
       defaultProps,
@@ -157,14 +171,19 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
 
     const isEnabled = disabled !== undefined ? !disabled : enabled;
 
+    // Per-component metadata overrides the PressablesConfig metadata.
+    const metadata = metadataProp ?? metadataProvider;
+
     const lastTouchedPressable = useLastTouchedPressable();
     const pressableId = useId();
 
+    // skipGlobalHandlers opts this pressable out of the provider handlers,
+    // while its own onPress/onPressIn/onPressOut still fire.
     const {
       onPressIn: onPressInProvider,
       onPressOut: onPressOutProvider,
       onPress: onPressProvider,
-    } = globalHandlers ?? {};
+    } = skipGlobalHandlers ? {} : (globalHandlers ?? {});
 
     const active = useSharedValue(false);
     const isToggled = useSharedValue(initialToggled);
@@ -214,6 +233,7 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
         isPressed: active.get(),
         isToggled: isToggled.get(),
         isSelected: lastTouchedPressable.get() === pressableId,
+        metadata,
       };
       onPressInProvider?.(options);
       onPressIn?.(options);
@@ -224,6 +244,7 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
       isToggled,
       lastTouchedPressable,
       pressableId,
+      metadata,
     ]);
 
     const onPressWrapper = useCallback(() => {
@@ -234,6 +255,7 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
         isPressed: active.get(),
         isToggled: isToggled.get(),
         isSelected: lastTouchedPressable.get() === pressableId,
+        metadata,
       };
       onPressProvider?.(options);
       onPress?.(options);
@@ -244,6 +266,7 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
       isToggled,
       lastTouchedPressable,
       pressableId,
+      metadata,
     ]);
 
     const onPressOutWrapper = useCallback(() => {
@@ -252,6 +275,7 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
         isPressed: active.get(),
         isToggled: isToggled.get(),
         isSelected: lastTouchedPressable.get() === pressableId,
+        metadata,
       };
       onPressOutProvider?.(options);
       onPressOut?.(options);
@@ -262,6 +286,7 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
       isToggled,
       lastTouchedPressable,
       pressableId,
+      metadata,
     ]);
 
     // Determine if hover should be enabled (web only)

--- a/src/pressables/base.tsx
+++ b/src/pressables/base.tsx
@@ -92,9 +92,12 @@ export type BasePressableProps<TMetadata = unknown> = {
   accessibilityIdentifier?: string;
   /**
    * Per-component metadata, surfaced to `animatedStyle` and to the press
-   * handler options (including globalHandlers). Overrides the metadata set on
-   * PressablesConfig. Use it to identify a pressable inside a global handler
-   * (e.g. analytics name) or carry flags it should react to.
+   * handler options (including globalHandlers). Use it to identify a pressable
+   * inside a global handler (e.g. analytics name) or carry flags it reacts to.
+   *
+   * REPLACES (does not merge with) the `metadata` set on PressablesConfig.
+   * To combine both, spread them yourself:
+   * `metadata={{ ...theme, name: 'checkout' }}`.
    */
   metadata?: TMetadata;
   /**

--- a/src/pressables/base.tsx
+++ b/src/pressables/base.tsx
@@ -24,6 +24,13 @@ export type AnimatedPressableStyleOptions<TMetadata = unknown> = {
   isPressed: boolean;
   isToggled: boolean;
   isSelected: boolean;
+  /**
+   * Required here (unlike the optional `metadata` in the press-handler
+   * options): the themed `animatedStyle` pattern assumes you set `metadata` on
+   * PressablesConfig, and typing it optional would force `?.` into every
+   * existing worklet. Handlers, by contrast, may run on a pressable that never
+   * set metadata, so there it is optional.
+   */
   metadata: TMetadata;
   config: PressableConfig;
   /**
@@ -227,67 +234,49 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
       return lastTouchedPressable.get() === pressableId;
     }, [lastTouchedPressable, pressableId]);
 
-    const onPressInWrapper = useCallback(() => {
-      active.set(true);
-      const options: AnimatedPressableOptions = {
+    // Snapshot the current interaction state into the options object passed to
+    // every handler. Reads live shared values, so callers mutate state first
+    // (active/isToggled/lastTouchedPressable) and then build.
+    const buildOptions = useCallback(
+      (): AnimatedPressableOptions => ({
         isPressed: active.get(),
         isToggled: isToggled.get(),
         isSelected: lastTouchedPressable.get() === pressableId,
         metadata,
-      };
+      }),
+      [active, isToggled, lastTouchedPressable, pressableId, metadata]
+    );
+
+    const onPressInWrapper = useCallback(() => {
+      active.set(true);
+      const options = buildOptions();
       onPressInProvider?.(options);
       onPressIn?.(options);
-    }, [
-      active,
-      onPressIn,
-      onPressInProvider,
-      isToggled,
-      lastTouchedPressable,
-      pressableId,
-      metadata,
-    ]);
+    }, [active, buildOptions, onPressIn, onPressInProvider]);
 
     const onPressWrapper = useCallback(() => {
       active.set(false);
       isToggled.set(!isToggled.get());
       lastTouchedPressable.set(pressableId);
-      const options: AnimatedPressableOptions = {
-        isPressed: active.get(),
-        isToggled: isToggled.get(),
-        isSelected: lastTouchedPressable.get() === pressableId,
-        metadata,
-      };
+      const options = buildOptions();
       onPressProvider?.(options);
       onPress?.(options);
     }, [
       active,
-      onPress,
-      onPressProvider,
       isToggled,
       lastTouchedPressable,
       pressableId,
-      metadata,
+      buildOptions,
+      onPress,
+      onPressProvider,
     ]);
 
     const onPressOutWrapper = useCallback(() => {
       active.set(false);
-      const options: AnimatedPressableOptions = {
-        isPressed: active.get(),
-        isToggled: isToggled.get(),
-        isSelected: lastTouchedPressable.get() === pressableId,
-        metadata,
-      };
+      const options = buildOptions();
       onPressOutProvider?.(options);
       onPressOut?.(options);
-    }, [
-      active,
-      onPressOut,
-      onPressOutProvider,
-      isToggled,
-      lastTouchedPressable,
-      pressableId,
-      metadata,
-    ]);
+    }, [active, buildOptions, onPressOut, onPressOutProvider]);
 
     // Determine if hover should be enabled (web only)
     const shouldEnableHover =

--- a/src/pressables/hoc.tsx
+++ b/src/pressables/hoc.tsx
@@ -15,7 +15,10 @@ export type {
   PressableChildrenCallbackParams,
 };
 
-export type CustomPressableProps = Omit<BasePressableProps, 'animatedStyle'>;
+export type CustomPressableProps<TMetadata = unknown> = Omit<
+  BasePressableProps<TMetadata>,
+  'animatedStyle'
+>;
 
 const withAnimatedTapStyle = <TMetadata = unknown,>(
   WrappedComponent: React.ComponentType<BasePressableProps<TMetadata>>,
@@ -24,7 +27,7 @@ const withAnimatedTapStyle = <TMetadata = unknown,>(
     options: AnimatedPressableStyleOptions<TMetadata>
   ) => ViewStyle
 ) => {
-  return (props: CustomPressableProps) => {
+  return (props: CustomPressableProps<TMetadata>) => {
     return <WrappedComponent {...props} animatedStyle={animatedStyle} />;
   };
 };

--- a/src/provider/context.ts
+++ b/src/provider/context.ts
@@ -14,10 +14,16 @@ import {
 
 export type AnimationType = 'timing' | 'spring';
 
-export type AnimatedPressableOptions = {
+export type AnimatedPressableOptions<TMetadata = unknown> = {
   isPressed: boolean;
   isToggled: boolean;
   isSelected: boolean;
+  /**
+   * Per-component metadata (falls back to the PressablesConfig metadata).
+   * Useful inside globalHandlers to identify which pressable fired.
+   * Optional: a pressable may not set it, so handlers should null-check.
+   */
+  metadata?: TMetadata;
 };
 
 export type PressableContextType<
@@ -27,9 +33,9 @@ export type PressableContextType<
   animationType: T;
   animationConfig: T extends 'timing' ? WithTimingConfig : WithSpringConfig;
   globalHandlers?: {
-    onPressIn?: (options: AnimatedPressableOptions) => void;
-    onPressOut?: (options: AnimatedPressableOptions) => void;
-    onPress?: (options: AnimatedPressableOptions) => void;
+    onPressIn?: (options: AnimatedPressableOptions<TMetadata>) => void;
+    onPressOut?: (options: AnimatedPressableOptions<TMetadata>) => void;
+    onPress?: (options: AnimatedPressableOptions<TMetadata>) => void;
   };
   metadata?: TMetadata;
   /**

--- a/src/provider/index.tsx
+++ b/src/provider/index.tsx
@@ -16,6 +16,7 @@ import {
   PressablesGroupContext,
   type AnimatedPressableOptions,
   type AnimationType,
+  type PressableContextType,
 } from './context';
 
 export type PressablesConfigProps<
@@ -26,9 +27,9 @@ export type PressablesConfigProps<
   animationType?: T;
   animationConfig?: T extends 'timing' ? WithTimingConfig : WithSpringConfig;
   globalHandlers?: {
-    onPressIn?: (options: AnimatedPressableOptions) => void;
-    onPressOut?: (options: AnimatedPressableOptions) => void;
-    onPress?: (options: AnimatedPressableOptions) => void;
+    onPressIn?: (options: AnimatedPressableOptions<TMetadata>) => void;
+    onPressOut?: (options: AnimatedPressableOptions<TMetadata>) => void;
+    onPress?: (options: AnimatedPressableOptions<TMetadata>) => void;
   };
   metadata?: TMetadata;
   /**
@@ -92,7 +93,11 @@ export const PressablesConfig = <T extends AnimationType, TMetadata = unknown>({
   }, [animationType, animationConfig, globalHandlers, metadata, activateOnHover, config, defaultProps]);
 
   return (
-    <PressablesContext.Provider value={value}>
+    // metadata-typed handlers are erased to `unknown` at the context boundary;
+    // BasePressable re-applies TMetadata via createAnimatedPressable<TMetadata>.
+    <PressablesContext.Provider
+      value={value as PressableContextType<AnimationType>}
+    >
       <PressablesGroup>{children}</PressablesGroup>
     </PressablesContext.Provider>
   );


### PR DESCRIPTION
## Summary

Two complementary additions that finish the existing `metadata` primitive and give per-component control over global handlers. Closes **#26** and **#30**.

### `metadata` per component → handlers (#26)
`metadata` was already a pressto concept but only settable on `PressablesConfig` (global) and only surfaced to `animatedStyle`. Now:
- settable per pressable (`<PressableScale metadata={{ name: 'checkout' }} />`)
- surfaced to the press-handler options (`onPress`/`onPressIn`/`onPressOut`), **including `globalHandlers`** — so a global handler can tell which pressable fired (the #26 analytics/`sentry-debug` use case)
- per-component value overrides the `PressablesConfig` metadata; still flows to `animatedStyle`
- `AnimatedPressableOptions` is now generic over `TMetadata`; the options field is optional (a pressable may omit it, so handlers null-check)

```tsx
<PressablesConfig globalHandlers={{ onPress: ({ metadata }) => track('tap', metadata?.name) }}>
  <PressableScale metadata={{ name: 'checkout' }} />
</PressablesConfig>
```

### `skipGlobalHandlers` (#30)
Boolean prop to opt a single pressable out of the `PressablesConfig` global handlers — its own `onPress`/`onPressIn`/`onPressOut` still fire. Solves "global haptics, except this button".

```tsx
<PressableScale skipGlobalHandlers onPress={() => {}} />
```

Chosen over the community `disableGlobalHandlers` boolean patch name: `skip` avoids confusion with the newly added `disabled` prop.

## Test plan

- [x] 11 new tests (`metadata.test.tsx`, `skip-global-handlers.test.tsx`); 63 total
- [x] typecheck + lint pass
- [x] README updated

## Notes
- `AnimatedPressableOptions<TMetadata>` is generic with `TMetadata = unknown` default — backwards compatible. Built-in pressables stay `unknown`; typed metadata via `createAnimatedPressable<T>()`.
- Provider casts the context value to erase `TMetadata` at the boundary (handlers are contravariant); `BasePressable` re-applies the type via `createAnimatedPressable<TMetadata>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)