### PR TITLE
feat: per-component config prop (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ function App() {
 - `animationConfig`: Pass timing or spring configuration
 - `config`: Set default values for `minScale`, `activeOpacity`, `baseScale`
 
+Override the config on a single pressable with the `config` prop — it shallow-merges over the `PressablesConfig` values, so you can change just one:
+
+```jsx
+{/* Inherits the rest of the config, only changes activeOpacity */}
+<PressableOpacity config={{ activeOpacity: 0.7 }} />
+
+<PressableScale config={{ minScale: 0.9 }} />
+```
+
 ### Default Props
 
 Set default props for all pressables globally. Useful for platform-specific behavior like disabling the Android ripple effect:
@@ -324,6 +333,7 @@ Every pressable (`PressableScale`, `PressableOpacity`, custom ones from `createA
 - `disabled`: boolean - Disables interaction (replaces the deprecated `enabled`)
 - `metadata`: TMetadata - Per-component metadata; passed to the handlers (incl. `globalHandlers`). Replaces (does not merge with) the `PressablesConfig` metadata
 - `skipGlobalHandlers`: boolean - Opt out of `PressablesConfig` `globalHandlers` (own handlers still fire)
+- `config`: `Partial<{ activeOpacity, minScale, baseScale }>` - Per-component visual config; shallow-merges over the `PressablesConfig` config
 - `accessibilityIdentifier`: string - Native id for e2e runners; defaults to `testID`
 - `initialToggled`: boolean - Initial toggle state
 - `activateOnHover`: boolean - Web only

--- a/src/__tests__/per-component-config.test.tsx
+++ b/src/__tests__/per-component-config.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react-native';
+
+import { createAnimatedPressable } from '../pressables/hoc';
+import { PressableScale } from '../pressables/custom/scale';
+import { PressablesConfig } from '../provider';
+
+// Probe pressable that echoes the resolved config straight into the style,
+// so config plumbing is observable without needing a real press animation.
+const ConfigProbe = createAnimatedPressable((_progress, { config }) => {
+  'worklet';
+  return {
+    opacity: config.activeOpacity,
+    transform: [{ scale: config.minScale }],
+    margin: config.baseScale,
+  };
+});
+
+const animatedStyleOf = (testID: string) =>
+  screen.getByTestId(testID).props.style[1];
+
+describe('per-component config (#25)', () => {
+  it('reaches animatedStyle from a component-level config prop', () => {
+    render(
+      <ConfigProbe
+        testID="p"
+        config={{ activeOpacity: 0.7, minScale: 0.9, baseScale: 1.1 }}
+      />
+    );
+    expect(animatedStyleOf('p')).toEqual({
+      opacity: 0.7,
+      transform: [{ scale: 0.9 }],
+      margin: 1.1,
+    });
+  });
+
+  it('shallow-merges over PressablesConfig config (override one key, keep rest)', () => {
+    render(
+      <PressablesConfig config={{ activeOpacity: 0.3, minScale: 0.8 }}>
+        <ConfigProbe testID="p" config={{ activeOpacity: 0.7 }} />
+      </PressablesConfig>
+    );
+    // activeOpacity overridden per component; minScale inherited from config;
+    // baseScale falls back to the default (1).
+    expect(animatedStyleOf('p')).toEqual({
+      opacity: 0.7,
+      transform: [{ scale: 0.8 }],
+      margin: 1,
+    });
+  });
+
+  it('falls back to defaults when nothing is set', () => {
+    render(<ConfigProbe testID="p" />);
+    expect(animatedStyleOf('p')).toEqual({
+      opacity: 0.5, // DefaultPressableConfig.activeOpacity
+      transform: [{ scale: 0.96 }], // minScale
+      margin: 1, // baseScale
+    });
+  });
+
+  it('PressableScale honours a per-component baseScale at idle', () => {
+    render(<PressableScale testID="p" config={{ baseScale: 2 }} />);
+    // idle progress=0 -> scale = baseScale
+    expect(animatedStyleOf('p')).toEqual({ transform: [{ scale: 2 }] });
+  });
+
+  it('component config wins over PressablesConfig for the same key', () => {
+    render(
+      <PressablesConfig config={{ baseScale: 1.5 }}>
+        <PressableScale testID="p" config={{ baseScale: 3 }} />
+      </PressablesConfig>
+    );
+    expect(animatedStyleOf('p')).toEqual({ transform: [{ scale: 3 }] });
+  });
+});

--- a/src/pressables/base.tsx
+++ b/src/pressables/base.tsx
@@ -105,6 +105,13 @@ export type BasePressableProps<TMetadata = unknown> = {
    * The component's own onPress/onPressIn/onPressOut still fire.
    */
   skipGlobalHandlers?: boolean;
+  /**
+   * Per-component visual config (activeOpacity, minScale, baseScale).
+   * MERGES with (shallow, per key) the config from PressablesConfig, so you can
+   * override a single value: `config={{ activeOpacity: 0.7 }}`. Merge is safe
+   * here (unlike `metadata`) because the config shape is fixed and known.
+   */
+  config?: Partial<PressableConfig>;
   initialToggled?: boolean;
   /**
    * Activates the pressable animation on hover (web only)
@@ -165,6 +172,7 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
     accessibilityIdentifier: accessibilityIdentifierProp,
     metadata: metadataProp,
     skipGlobalHandlers = false,
+    config: configProp,
     initialToggled = false,
     activateOnHover: activateOnHoverProp,
     ...rest
@@ -175,7 +183,7 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
       globalHandlers,
       metadata: metadataProvider,
       activateOnHover: activateOnHoverProvider,
-      config,
+      config: configProvider,
       defaultProps,
     } = usePressablesConfig();
 
@@ -183,6 +191,13 @@ const BasePressable: React.FC<BasePressableProps> = React.memo(
 
     // Per-component metadata overrides the PressablesConfig metadata.
     const metadata = metadataProp ?? metadataProvider;
+
+    // Per-component config shallow-merges over the PressablesConfig config,
+    // so a single key (e.g. activeOpacity) can be overridden per pressable.
+    const config = useMemo(
+      () => ({ ...configProvider, ...configProp }),
+      [configProvider, configProp]
+    );
 
     const lastTouchedPressable = useLastTouchedPressable();
     const pressableId = useId();


### PR DESCRIPTION
## Summary

Adds a per-component **`config`** prop (closes #25 — the top-requested open issue, 7 reactions). Until now `activeOpacity` / `minScale` / `baseScale` could only be set globally via `PressablesConfig`.

```tsx
<PressableOpacity config={{ activeOpacity: 0.7 }} />
<PressableScale config={{ minScale: 0.9 }} />
```

- **Shallow-merges** over the `PressablesConfig` config, so you override a single key and inherit the rest.
- Precedence: **component `config` → `PressablesConfig` config → defaults**.
- Flows into `animatedStyle` (same `options.config` custom pressables already read).
- Destructured out of props, so it never leaks to the native `BaseButton`.

### Why merge here, but `metadata` replaces
`config` has a **fixed, known shape** (three numeric keys), so a shallow per-key merge is sound and is what you want (change `minScale`, keep the rest). `metadata` is an opaque generic bag where merge is unsound (primitives) and hides provenance — hence it replaces. The asymmetry is intentional and documented in both props' JSDoc.

## Test plan
- [x] 5 new tests (`per-component-config.test.tsx`): config reaches `animatedStyle`, shallow-merge over global, component-wins precedence, defaults fallback, real `PressableScale` idle `baseScale`. 86 total.
- [x] typecheck + lint pass
- [x] README updated (usage + per-pressable props reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)